### PR TITLE
Change configuration representation language

### DIFF
--- a/api/v1/job.php
+++ b/api/v1/job.php
@@ -96,7 +96,7 @@ class Job_API extends API {
         $sys = new System($system->getId());
         $data->system = $sys->getIdentifier();
         $data->environment = $job->getEnvironment();
-        $data->cdl = $job->getCdl();
+        $data->cdl = Util::jsonToCDL($job);
 
         $data->created = $job->getCreated();
         $data->started = $job->getStarted();

--- a/chronos.sql
+++ b/chronos.sql
@@ -59,7 +59,7 @@ CREATE TABLE `Job` (
   `systemId` int(11) NOT NULL,
   `environment` varchar(256) COLLATE utf8_unicode_ci NOT NULL,
   `phases` int(11) NOT NULL,
-  `cdl` text COLLATE utf8_unicode_ci NOT NULL,
+  `configuration` text COLLATE utf8_unicode_ci NOT NULL,
   `status` int(11) NOT NULL,
   `progress` int(11) NOT NULL,
   `result` mediumtext COLLATE utf8_unicode_ci NOT NULL,

--- a/controllers/builder.php
+++ b/controllers/builder.php
@@ -115,30 +115,29 @@ class Builder_Controller extends Controller {
                 }
             }
 
-            $allCDL = array(new CDL_Library($system->getId()));
+            $allConfigurations = [[Define::CONFIGURATION_PARAMETERS => []]];
 
-            if($data['run-distribution'] == 'order'){
-                Builder_Library::apply_runs($data, $allCDL);
+            if ($data['run-distribution'] == 'order') {
+                Builder_Library::apply_runs($data, $allConfigurations);
             }
 
             foreach ($multiElements as $element) {
                 /** @var $elem Element */
                 $elem = $element['obj'];
-                $elem->process($data, $element['parameter'], $allCDL);
+                $elem->process($data, $element['parameter'], $allConfigurations);
             }
-  
+
             foreach ($singleElements as $element) {
                 /** @var $elem Element */
                 $elem = $element['obj'];
-                $elem->process($data, $element['parameter'], $allCDL);
+                $elem->process($data, $element['parameter'], $allConfigurations);
             }
 
-            if($data['run-distribution'] == 'alter'){
-                Builder_Library::apply_runs($data, $allCDL);
-            }
-            else if($data['run-distribution'] == 'rand'){
-                Builder_Library::apply_runs($data, $allCDL);
-                shuffle($allCDL);
+            if ($data['run-distribution'] == 'alter') {
+                Builder_Library::apply_runs($data, $allConfigurations);
+            } else if ($data['run-distribution'] == 'rand') {
+                Builder_Library::apply_runs($data, $allConfigurations);
+                shuffle($allConfigurations);
             }
 
             $qF = new QueryFilter(Evaluation::EXPERIMENT_ID, $experiment->getId(), "=");
@@ -150,8 +149,8 @@ class Builder_Controller extends Controller {
                 "A new evaluation of experiment '" . $experiment->getName() . "' was started.", Define::EVENT_EVALUATION, $ev->getId(), $user->getId());
             $FACTORIES::getEventFactory()->save($event);
 
-            foreach ($allCDL as $cdl) {
-                $evaluation->addEvaluationJob($experiment->getName(), $cdl);
+            foreach ($allConfigurations as $configuration) {
+                $evaluation->addEvaluationJob($experiment->getName(), $configuration);
             }
 
             $evaluation->generateJobs((empty($data['deployment'])) ? '' : $data['deployment'], $data, $ev);

--- a/controllers/job.php
+++ b/controllers/job.php
@@ -120,6 +120,7 @@ class Job_Controller extends Controller {
                 }
 
                 $this->view->assign('job', $job);
+                $this->view->assign('cdl', Util::jsonToCDL($job));
                 $this->view->assign('phases', Util::getObjectFromPhasesBitMask($job->getPhases()));
                 $this->view->assign('user', $FACTORIES::getUserFactory()->get($job->getUserId()));
                 $evaluation = $FACTORIES::getEvaluationFactory()->get($job->getEvaluationId());

--- a/core/define.php
+++ b/core/define.php
@@ -45,4 +45,6 @@ class Define {
     const EVENT_EVALUATION = "evaluation";
     const EVENT_JOB = "job";
     const EVENT_USER = "user";
+
+    const CONFIGURATION_PARAMETERS = "parameters";
 }

--- a/core/element.php
+++ b/core/element.php
@@ -67,26 +67,24 @@ class Element {
     /**
      * @param $data
      * @param $parameter
-     * @param $allCDL CDL_Library[]
+     * @param $allConfigurations [][]
      * @throws Exception
      */
-    public function process($data, $parameter, &$allCDL) {
-        // when generating multi-job, we need to copy the current CDLs and apply our setting for every of them
+    public function process($data, $parameter, &$allConfigurations) {
+        // when generating multi-job, we need to copy the current configurations and apply our setting for every of them
         if (file_exists($this->path . "process.php")) {
             // we include the external process function
             include($this->path . "process.php");
         } else {
             // default handling
-            // TODO: do default processing here
             if ($this->generatesMultiJob()) {
                 // multi-jobs are too complicated for any default
                 throw new Exception("Multijobs need to have process to create evaluations!");
             } else {
-                // add this value too all CDLs
-                foreach ($allCDL as &$cdl) {
-                    // default: take the parameter value (which should be the same name by default) and add it to the CDL
-                    $eval = $cdl->getEvaluation();
-                    $eval->appendChild($cdl->createElement($parameter, $data[$parameter]));
+                // add this value too all configurations
+                foreach ($allConfigurations as &$configuration) {
+                    // default: take the parameter value (which should be the same name by default) and add it to the configuration
+                    $configuration[Define::CONFIGURATION_PARAMETERS][$parameter] = $data[$parameter];
                 }
             }
         }

--- a/core/util.php
+++ b/core/util.php
@@ -97,7 +97,7 @@ class Util {
         $parameters = $preparedJobs[0]->getConfiguration()[Define::CONFIGURATION_PARAMETERS];
         foreach ($parameters as $param => $val) {
             foreach ($preparedJobs as $preparedJob) {
-                $eval = $preparedJob[Define::CONFIGURATION_PARAMETERS];
+                $eval = $preparedJob->getConfiguration()[Define::CONFIGURATION_PARAMETERS];
                 if ($eval[$param] != $val && !in_array($param, $variations)) {
                     $variations[] = $param;
                 }

--- a/core/util.php
+++ b/core/util.php
@@ -129,7 +129,7 @@ class Util {
         foreach ($preparedJobs as $preparedJob) {
             $groupMatched = false;
             foreach ($groupArrays as $index => $arr) {
-                $diff = array_diff($preparedJob->getConfiguration()[Define::CONFIGURATION_PARAMETERS], $arr);
+                $diff = array_diff($preparedJob[0]->getConfiguration()[Define::CONFIGURATION_PARAMETERS], $arr);
                 $match = true;
                 foreach ($diff as $k => $d) {
                     if (!in_array($k, $parameter)) {
@@ -148,7 +148,7 @@ class Util {
 
             if ($groupMatched === false) {
                 $jobGroup[] = [$preparedJob];
-                $groupArrays[] = $preparedJob->getConfiguration()[Define::CONFIGURATION_PARAMETERS];
+                $groupArrays[] = $preparedJob[0]->getConfiguration()[Define::CONFIGURATION_PARAMETERS];
             } else {
                 $jobGroup[$groupMatched][] = $preparedJob;
             }
@@ -160,8 +160,8 @@ class Util {
                 continue;
             }
             foreach ($preparedJobs as $preparedJob) {
-                if (!in_array($preparedJob->getConfiguration()[Define::CONFIGURATION_PARAMETERS][$l], $labels)) {
-                    $labels[] = $preparedJob->getConfiguration()[Define::CONFIGURATION_PARAMETERS][$l];
+                if (!in_array($preparedJob[0]->getConfiguration()[Define::CONFIGURATION_PARAMETERS][$l], $labels)) {
+                    $labels[] = $preparedJob[0]->getConfiguration()[Define::CONFIGURATION_PARAMETERS][$l];
                 }
             }
         }

--- a/core/util.php
+++ b/core/util.php
@@ -80,13 +80,14 @@ class Util {
     public static function getDifferentParameters($jobs) {
         $preparedJobs = [];
         foreach ($jobs as $j) {
-            if(is_array($j)){
+            if (is_array($j)) {
                 $job = $j[0];
-            }
-            else{
+            } else {
                 $job = $j;
             }
-            $job->setConfiguration(json_decode($job->getConfiguration(), TRUE));
+            if (!is_array($job->getConfiguration())) { // decode if required
+                $job->setConfiguration(json_decode($job->getConfiguration(), TRUE));
+            }
             $preparedJobs[] = $job;
         }
 
@@ -154,7 +155,7 @@ class Util {
 
         $labels = [];
         foreach ($internLabels as $l) {
-            if($l == 'run'){
+            if ($l == 'run') {
                 continue;
             }
             foreach ($preparedJobs as $preparedJob) {
@@ -163,9 +164,9 @@ class Util {
                 }
             }
         }
-        
-        if(sizeof($labels) == 0){
-          $labels[] = $parameter;
+
+        if (sizeof($labels) == 0) {
+            $labels[] = $parameter;
         }
 
         return [$jobGroup, $labels];
@@ -408,13 +409,13 @@ class Util {
             Define::EVENT_JOB
         ];
         $filteredEvents = [];
-        foreach($types as $type){
+        foreach ($types as $type) {
             $oF1 = new OrderFilter(Event::TIME, "DESC");
             $oF2 = new OrderFilter(Event::EVENT_ID, "DESC LIMIT $limit");
             $qF1 = new ContainFilter(Event::RELATED_ID, Util::arrayOfIds($toload[$type]));
             $qF2 = new QueryFilter(Event::EVENT_TYPE, $type, "=");
             $events = $FACTORIES::getEventFactory()->filter([$FACTORIES::ORDER => [$oF1, $oF2], $FACTORIES::FILTER => [$qF1, $qF2]]);
-            foreach($events as $event){
+            foreach ($events as $event) {
                 $filteredEvents[$event->getId()] = $event;
             }
         }

--- a/core/util.php
+++ b/core/util.php
@@ -117,9 +117,10 @@ class Util {
         // prepare all arrays
         $preparedJobs = [];
         foreach ($jobs as $j) {
-            $job = $j[0];
-            $job->setConfiguration(json_decode($job->getConfiguration(), TRUE));
-            $preparedJobs[] = $job;
+            foreach ($j as &$job) {
+                $job->setConfiguration(json_decode($job->getConfiguration(), TRUE));
+            }
+            $preparedJobs[] = $j;
         }
 
         $jobGroup = [];

--- a/core/util.php
+++ b/core/util.php
@@ -118,7 +118,9 @@ class Util {
         $preparedJobs = [];
         foreach ($jobs as $j) {
             foreach ($j as &$job) {
-                $job->setConfiguration(json_decode($job->getConfiguration(), TRUE));
+                if(!is_array($job->getConfiguration())) { // only decode if needed
+                    $job->setConfiguration(json_decode($job->getConfiguration(), TRUE));
+                }
             }
             $preparedJobs[] = $j;
         }

--- a/libraries/builder.php
+++ b/libraries/builder.php
@@ -50,7 +50,7 @@ class Builder_Library {
         }
         for ($i = 0; $i < intval($data["runs"]); $i++) {
             foreach ($allConfigurations as $configuration) {
-                $copy = clone $configuration;
+                $copy = $configuration;
                 $copy[Define::CONFIGURATION_PARAMETERS]["run"] = $i;
                 $newConfigurations[] = $copy;
             }

--- a/libraries/builder.php
+++ b/libraries/builder.php
@@ -40,23 +40,22 @@ class Builder_Library {
 
     /**
      * @param $data
-     * @param $allCDL CDL_Library[]
+     * @param $allConfigurations
      * @throws Exception
      */
-    public static function apply_runs($data, &$allCDL){
-        $newCDL = [];
+    public static function apply_runs($data, &$allConfigurations) {
+        $newConfigurations = [];
         if (intval($data["runs"]) <= 0) {
             throw new Exception("Invalid run number!");
         }
-        for ($i=0;$i<intval($data["runs"]);$i++) {
-            foreach ($allCDL as $cdl) {
-                $ccdl = clone $cdl;
-                $eval = $ccdl->getEvaluation();
-                $eval->appendChild($ccdl->createElement("run", $i));
-                $newCDL[] = $ccdl;
+        for ($i = 0; $i < intval($data["runs"]); $i++) {
+            foreach ($allConfigurations as $configuration) {
+                $copy = clone $configuration;
+                $copy[Define::CONFIGURATION_PARAMETERS]["run"] = $i;
+                $newConfigurations[] = $copy;
             }
         }
-        $allCDL = $newCDL;
+        $allConfigurations = $newConfigurations;
     }
 
     /**
@@ -103,9 +102,9 @@ class Builder_Library {
         return $content;
     }
 
-    public function escapeArrayValues($arr){
+    public function escapeArrayValues($arr) {
         $escaped = [];
-        foreach($arr as $key => $val){
+        foreach ($arr as $key => $val) {
             $escaped[$key] = htmlentities($val, ENT_QUOTES, "UTF-8");
         }
         return $escaped;

--- a/libraries/dba/models/Job.class.php
+++ b/libraries/dba/models/Job.class.php
@@ -33,7 +33,7 @@ class Job extends AbstractModel {
   private $systemId;
   private $environment;
   private $phases;
-  private $cdl;
+  private $configuration;
   private $status;
   private $progress;
   private $result;
@@ -44,14 +44,14 @@ class Job extends AbstractModel {
   private $internalId;
   private $configurationIdentifier;
   
-  function __construct($jobId, $userId, $description, $systemId, $environment, $phases, $cdl, $status, $progress, $result, $created, $started, $finished, $evaluationId, $internalId, $configurationIdentifier) {
+  function __construct($jobId, $userId, $description, $systemId, $environment, $phases, $configuration, $status, $progress, $result, $created, $started, $finished, $evaluationId, $internalId, $configurationIdentifier) {
     $this->jobId = $jobId;
     $this->userId = $userId;
     $this->description = $description;
     $this->systemId = $systemId;
     $this->environment = $environment;
     $this->phases = $phases;
-    $this->cdl = $cdl;
+    $this->configuration = $configuration;
     $this->status = $status;
     $this->progress = $progress;
     $this->result = $result;
@@ -71,7 +71,7 @@ class Job extends AbstractModel {
     $dict['systemId'] = $this->systemId;
     $dict['environment'] = $this->environment;
     $dict['phases'] = $this->phases;
-    $dict['cdl'] = $this->cdl;
+    $dict['configuration'] = $this->configuration;
     $dict['status'] = $this->status;
     $dict['progress'] = $this->progress;
     $dict['result'] = $this->result;
@@ -141,12 +141,12 @@ class Job extends AbstractModel {
     $this->phases = $phases;
   }
   
-  function getCdl(){
-    return $this->cdl;
+  function getConfiguration(){
+    return $this->configuration;
   }
   
-  function setCdl($cdl){
-    $this->cdl = $cdl;
+  function setConfiguration($configuration){
+    $this->configuration = $configuration;
   }
   
   function getStatus(){
@@ -227,7 +227,7 @@ class Job extends AbstractModel {
   const SYSTEM_ID = "systemId";
   const ENVIRONMENT = "environment";
   const PHASES = "phases";
-  const CDL = "cdl";
+  const CONFIGURATION = "configuration";
   const STATUS = "status";
   const PROGRESS = "progress";
   const RESULT = "result";

--- a/libraries/dba/models/JobFactory.class.php
+++ b/libraries/dba/models/JobFactory.class.php
@@ -57,7 +57,7 @@ class JobFactory extends AbstractModelFactory {
    * @return Job
    */
   function createObjectFromDict($pk, $dict) {
-    $o = new Job($dict['jobId'], $dict['userId'], $dict['description'], $dict['systemId'], $dict['environment'], $dict['phases'], $dict['cdl'], $dict['status'], $dict['progress'], $dict['result'], $dict['created'], $dict['started'], $dict['finished'], $dict['evaluationId'], $dict['internalId'], $dict['configurationIdentifier']);
+    $o = new Job($dict['jobId'], $dict['userId'], $dict['description'], $dict['systemId'], $dict['environment'], $dict['phases'], $dict['configuration'], $dict['status'], $dict['progress'], $dict['result'], $dict['created'], $dict['started'], $dict['finished'], $dict['evaluationId'], $dict['internalId'], $dict['configurationIdentifier']);
     return $o;
   }
 

--- a/libraries/dba/models/generator.php
+++ b/libraries/dba/models/generator.php
@@ -83,7 +83,7 @@ $CONF['Job'] = array(
     'systemId',
     'environment',
     'phases',
-    'cdl',
+    'configuration',
     'status',
     'progress',
     'result',

--- a/libraries/elements/checkbox-selection/process.php
+++ b/libraries/elements/checkbox-selection/process.php
@@ -9,7 +9,7 @@
 
 /** @var $data array */
 /** @var $parameter string */
-/** @var $allConfigurations [] */
+/** @var $allConfigurations [][] */
 
 // when generating multi-job, we need to copy the current configurations and apply our setting for every of them
 // we have the interval, so we need to go from min to max in steps and copy all configurations and add the corresponding setting for each of them
@@ -19,7 +19,7 @@ foreach ($data as $param => $val) {
         $opt = str_replace($parameter . "-", "", $param);
         if ($data[$parameter . "-" . $opt] == 'on') {
             foreach ($allConfigurations as $configuration) {
-                $copy = clone $configuration;
+                $copy = $configuration;
                 $copy[Define::CONFIGURATION_PARAMETERS][$parameter] = $opt;
                 $newConfiguration[] = $copy;
             }

--- a/libraries/elements/checkbox-selection/process.php
+++ b/libraries/elements/checkbox-selection/process.php
@@ -4,28 +4,27 @@
  * Given values:
  * - $data: containing the full post data of the experiment creation
  * - $parameter: containing the name/basename of the parameter
- * - $allCDL: containing all current CDLs defined (this value is passed by reference, this is the only way to save stuff)
+ * - $allConfigurations: containing all current configurations defined (this value is passed by reference, this is the only way to save stuff)
  */
 
 /** @var $data array */
 /** @var $parameter string */
-/** @var $allCDL CDL_Library[] */
+/** @var $allConfigurations [] */
 
-// when generating multi-job, we need to copy the current CDLs and apply our setting for every of them
-// we have the interval, so we need to go from min to max in steps and copy all CDLs and add the corresponding setting for each of them
-$newCDL = [];
+// when generating multi-job, we need to copy the current configurations and apply our setting for every of them
+// we have the interval, so we need to go from min to max in steps and copy all configurations and add the corresponding setting for each of them
+$newConfiguration = [];
 foreach ($data as $param => $val) {
     if (strpos($param, $parameter . "-") === 0) {
         $opt = str_replace($parameter . "-", "", $param);
         if ($data[$parameter . "-" . $opt] == 'on') {
-            foreach ($allCDL as $cdl) {
-                $ccdl = clone $cdl;
-                $eval = $ccdl->getEvaluation();
-                $eval->appendChild($ccdl->createElement($parameter, $opt));
-                $newCDL[] = $ccdl;
+            foreach ($allConfigurations as $configuration) {
+                $copy = clone $configuration;
+                $copy[Define::CONFIGURATION_PARAMETERS][$parameter] = $opt;
+                $newConfiguration[] = $copy;
             }
         }
     }
 }
 
-$allCDL = $newCDL;
+$allConfigurations = $newConfiguration;

--- a/libraries/elements/interval/process.php
+++ b/libraries/elements/interval/process.php
@@ -19,7 +19,7 @@ if (intval($data[$parameter . "-step"]) == 0) {
 }
 for ($i = intval($data[$parameter . "-min"]); $i <= intval($data[$parameter . "-max"]); $i += intval($data[$parameter . "-step"])) {
     foreach ($allConfigurations as $configuration) {
-        $copy = clone $configuration;
+        $copy = $configuration;
         $copy[Define::CONFIGURATION_PARAMETERS][$parameter] = $i;
         $newConfigurations[] = $copy;
     }

--- a/libraries/elements/interval/process.php
+++ b/libraries/elements/interval/process.php
@@ -4,25 +4,24 @@
  * Given values:
  * - $data: containing the full post data of the experiment creation
  * - $parameter: containing the name/basename of the parameter
- * - $allCDL: containing all current CDLs defined (this value is passed by reference, this is the only way to save stuff)
+ * - $allConfigurations: containing all current configurations defined (this value is passed by reference, this is the only way to save stuff)
  */
 
 /** @var $data array */
 /** @var $parameter string */
-/** @var $allCDL CDL_Library[] */
+/** @var $allConfigurations [] */
 
-// when generating multi-job, we need to copy the current CDLs and apply our setting for every of them
-// we have the interval, so we need to go from min to max in steps and copy all CDLs and add the corresponding setting for each of them
-$newCDL = [];
+// when generating multi-job, we need to copy the current configurations and apply our setting for every of them
+// we have the interval, so we need to go from min to max in steps and copy all configurations and add the corresponding setting for each of them
+$newConfigurations = [];
 if (intval($data[$parameter . "-step"]) == 0) {
     throw new Exception("Invalid step size causing endless loop!");
 }
 for ($i = intval($data[$parameter . "-min"]); $i <= intval($data[$parameter . "-max"]); $i += intval($data[$parameter . "-step"])) {
-    foreach ($allCDL as $cdl) {
-        $ccdl = clone $cdl;
-        $eval = $ccdl->getEvaluation();
-        $eval->appendChild($ccdl->createElement($parameter, $i));
-        $newCDL[] = $ccdl;
+    foreach ($allConfigurations as $configuration) {
+        $copy = clone $configuration;
+        $copy[Define::CONFIGURATION_PARAMETERS][$parameter] = $i;
+        $newConfigurations[] = $copy;
     }
 }
-$allCDL = $newCDL;
+$allConfigurations = $newConfigurations;

--- a/libraries/elements/ratio/process.php
+++ b/libraries/elements/ratio/process.php
@@ -4,16 +4,16 @@
  * Given values:
  * - $data: containing the full post data of the experiment creation
  * - $parameter: containing the name/basename of the parameter
- * - $allCDL: containing all current CDLs defined (this value is passed by reference, this is the only way to save stuff)
+ * - $allConfigurations: containing all current configurations defined (this value is passed by reference, this is the only way to save stuff)
  */
 
 /** @var $data array */
 /** @var $parameter string */
-/** @var $allCDL CDL_Library[] */
+/** @var $allConfigurations [] */
 
-// when generating multi-job, we need to copy the current CDLs and apply our setting for every of them
-// we have the interval, so we need to go from min to max in steps and copy all CDLs and add the corresponding setting for each of them
-$newCDL = [];
+// when generating multi-job, we need to copy the current configurations and apply our setting for every of them
+// we have the interval, so we need to go from min to max in steps and copy all configurations and add the corresponding setting for each of them
+$newConfigurations = [];
 
 // parse ratios
 $start = explode(":", str_replace("%", "", $data[$parameter . "-start"]));
@@ -34,13 +34,12 @@ $params = explode(",", $parameter);
 
 $ratio = [intval($start[0]), intval($start[1])];
 for (; $ratio[0] <= $end[0]; $ratio[0] += intval($step), $ratio[1] -= intval($step)) {
-    foreach ($allCDL as $cdl) {
-        $ccdl = clone $cdl;
-        $eval = $ccdl->getEvaluation();
-        $eval->appendChild($ccdl->createElement($params[0], $ratio[0]));
-        $eval->appendChild($ccdl->createElement($params[1], $ratio[1]));
-        $newCDL[] = $ccdl;
+    foreach ($allConfigurations as $configuration) {
+        $copy = clone $configuration;
+        $copy[Define::CONFIGURATION_PARAMETERS][$params[0]] = $ratio[0];
+        $copy[Define::CONFIGURATION_PARAMETERS][$params[1]] = $ratio[1];
+        $newConfigurations[] = $copy;
     }
 }
 
-$allCDL = $newCDL;
+$allConfigurations = $newConfigurations;

--- a/libraries/elements/ratio/process.php
+++ b/libraries/elements/ratio/process.php
@@ -35,7 +35,7 @@ $params = explode(",", $parameter);
 $ratio = [intval($start[0]), intval($start[1])];
 for (; $ratio[0] <= $end[0]; $ratio[0] += intval($step), $ratio[1] -= intval($step)) {
     foreach ($allConfigurations as $configuration) {
-        $copy = clone $configuration;
+        $copy = $configuration;
         $copy[Define::CONFIGURATION_PARAMETERS][$params[0]] = $ratio[0];
         $copy[Define::CONFIGURATION_PARAMETERS][$params[1]] = $ratio[1];
         $newConfigurations[] = $copy;

--- a/libraries/elements/string-list/process.php
+++ b/libraries/elements/string-list/process.php
@@ -17,7 +17,7 @@ $newConfigurations = [];
 $split = explode(",", $data[$parameter]);
 foreach ($split as $value) {
     foreach ($allConfigurations as $configuration) {
-        $copy = clone $configuration;
+        $copy = $configuration;
         $copy[Define::CONFIGURATION_PARAMETERS][$parameter] = $value;
         $newConfigurations[] = $copy;
     }

--- a/libraries/elements/string-list/process.php
+++ b/libraries/elements/string-list/process.php
@@ -4,24 +4,23 @@
  * Given values:
  * - $data: containing the full post data of the experiment creation
  * - $parameter: containing the name/basename of the parameter
- * - $allCDL: containing all current CDLs defined (this value is passed by reference, this is the only way to save stuff)
+ * - $allConfigurations: containing all current configurations defined (this value is passed by reference, this is the only way to save stuff)
  */
 
 /** @var $data array */
 /** @var $parameter string */
-/** @var $allCDL CDL_Library[] */
+/** @var $allConfigurations [] */
 
-// when generating multi-job, we need to copy the current CDLs and apply our setting for every of them
-// we have the interval, so we need to go from min to max in steps and copy all CDLs and add the corresponding setting for each of them
-$newCDL = [];
+// when generating multi-job, we need to copy the current configurations and apply our setting for every of them
+// we have the interval, so we need to go from min to max in steps and copy all configurations and add the corresponding setting for each of them
+$newConfigurations = [];
 $split = explode(",", $data[$parameter]);
 foreach ($split as $value) {
-    foreach ($allCDL as $cdl) {
-        $ccdl = clone $cdl;
-        $eval = $ccdl->getEvaluation();
-        $eval->appendChild($ccdl->createElement($parameter, $value));
-        $newCDL[] = $ccdl;
+    foreach ($allConfigurations as $configuration) {
+        $copy = clone $configuration;
+        $copy[Define::CONFIGURATION_PARAMETERS][$parameter] = $value;
+        $newConfigurations[] = $copy;
     }
 }
 
-$allCDL = $newCDL;
+$allConfigurations = $newConfigurations;

--- a/libraries/evaluation.php
+++ b/libraries/evaluation.php
@@ -18,14 +18,14 @@ class Evaluation_Library {
 
     /**
      * @param $description
-     * @param $cdl CDL_Library
+     * @param $configuration []
      * @throws Exception
      */
-    public function addEvaluationJob($description, $cdl) {
+    public function addEvaluationJob($description, $configuration) {
         $job = [];
         $job['description'] = $description;
         $job['type'] = 2;
-        $job['cdl'] = $cdl->toXML();
+        $job['configuration'] = $configuration;
         $job['user'] = Auth_Library::getInstance()->getUserID();
         $job['system'] = $this->experiment->getSystemId();
         $this->jobs[] = $job;
@@ -49,7 +49,7 @@ class Evaluation_Library {
             $jobData['phase_analyze'] = isset($data['phase_analyze']) ? boolval($data['phase_analyze']) : true;
             $jobData['phase_clean'] = isset($data['phase_clean']) ? boolval($data['phase_clean']) : true;
 
-            $cdl = trim($jobData['cdl']);
+            $configuration = json_encode($jobData['configuration']);
             $phases = Util::calcPhasesBitMask($jobData['phase_prepare'], $jobData['phase_warmUp'], $jobData['phase_execute'], $jobData['phase_analyze'], $jobData['phase_clean']);
             $status = Define::JOB_STATUS_SCHEDULED;
 
@@ -58,7 +58,7 @@ class Evaluation_Library {
                 $jobData['description'],
                 $this->experiment->getSystemId(),
                 $environment,
-                $phases, $cdl, $status, 0, '',
+                $phases, $configuration, $status, 0, '',
                 date('Y-m-d H:i:s'), null, null,
                 $evaluation->getId(),
                 $count,

--- a/libraries/graphs/line-plot-multi/process.php
+++ b/libraries/graphs/line-plot-multi/process.php
@@ -44,7 +44,7 @@ for ($i = 0; $i < sizeof($jobGroups[0]); $i++) {
 $arr = Util::getDifferentParameters($jobs);
 $changingParameters = $arr[0];
 $jobParameters = $arr[1];
-print_r($jobGroups);
+
 foreach ($jobGroups as $jobGroup) {
     /** @var $jobGroup Job[][] */
     $jobIds = [];

--- a/libraries/graphs/line-plot-multi/process.php
+++ b/libraries/graphs/line-plot-multi/process.php
@@ -44,14 +44,14 @@ for ($i = 0; $i < sizeof($jobGroups[0]); $i++) {
 $arr = Util::getDifferentParameters($jobs);
 $changingParameters = $arr[0];
 $jobParameters = $arr[1];
-
+print_r($jobGroups);
 foreach ($jobGroups as $jobGroup) {
     /** @var $jobGroup Job[][] */
     $jobIds = [];
     $index = 0;
     foreach ($jobGroup as $j) {
         $sum = 0;
-        foreach($j as $job) {
+        foreach ($j as $job) {
             $results = json_decode($job->getResult(), true);
             foreach ($parameter as $p) {
                 if (isset($results[$allData['plotting']])) {
@@ -59,7 +59,7 @@ foreach ($jobGroups as $jobGroup) {
                 }
             }
         }
-        $parameterData[$index]['data'][] = $sum/sizeof($j);
+        $parameterData[$index]['data'][] = $sum / sizeof($j);
         $jobIds[] = $j[0]->getInternalId();
         $index++;
     }
@@ -67,8 +67,7 @@ foreach ($jobGroups as $jobGroup) {
     foreach ($changingParameters as $changingParameter) {
         if (in_array($changingParameter, $parameter)) {
             continue;
-        }
-        else if($changingParameter == 'run'){
+        } else if ($changingParameter == 'run') {
             continue;
         }
         $label[] = $changingParameter . ": " . $jobParameters[$jobGroup[0][0]->getId()][$changingParameter];

--- a/views/builder/create.php
+++ b/views/builder/create.php
@@ -61,7 +61,6 @@ SOFTWARE.
                                     <select name="run-distribution" class="form-control">
                                         <option value="alter">Alternating</option>
                                         <option value="order">Ascending</option>
-                                        <option value="rand">Random</option>
                                     </select>
                                 </div>
                                 <div class="form-group">

--- a/views/job/detail.php
+++ b/views/job/detail.php
@@ -261,7 +261,7 @@ $this->includeInlineJS("
                                 </div>
                                 <div class="modal-body">
                                     <pre style="" class="prettyprint prettyprinted">
-<code class="xml"><?php echo trim(htmlentities($data['job']->getCdl())); ?></code>
+<code class="xml"><?php echo trim(htmlentities($data['cdl'])); ?></code>
 							</pre>
                                 </div>
                                 <div class="modal-footer">


### PR DESCRIPTION
The configuration parameters for jobs are not saved in CDL format but in JSON. This allows easier read-out for processing of the results.
The CDL is generated if required for the API and web UI from the JSON.