### PR TITLE
Catch edge case for box plots to avoid errors

### DIFF
--- a/libraries/graphs/boxplot/process.php
+++ b/libraries/graphs/boxplot/process.php
@@ -57,7 +57,7 @@ foreach ($jobGroups as $jobGroup) {
                 }
             }
         }
-        if (sizeof($arr) < 2) {
+        if (sizeof($arr) < 3) {
             $notEnoughRuns = true;
             break;
         }

--- a/libraries/graphs/boxplot/process.php
+++ b/libraries/graphs/boxplot/process.php
@@ -41,6 +41,7 @@ for ($i = 0; $i < sizeof($jobGroups[0]); $i++) {
 $arr = Util::getDifferentParameters($jobs);
 $changingParameters = $arr[0];
 $jobParameters = $arr[1];
+$notEnoughRuns = false;
 
 foreach ($jobGroups as $jobGroup) {
     /** @var $jobGroup Job[][] */
@@ -55,6 +56,10 @@ foreach ($jobGroups as $jobGroup) {
                     $arr[] = floatval($results[$allData['plotting']]);
                 }
             }
+        }
+        if (sizeof($arr) < 2) {
+            $notEnoughRuns = true;
+            break;
         }
         $parameterData[$index]['data'][] = Results_Library::boxPlotCalculation($arr);
         $jobIds[] = $j[0]->getInternalId();
@@ -77,5 +82,6 @@ foreach ($parameterData as $pData) {
     $dataArray['datasets'][] = $pData;
     $dataArray['labels'] = $labels;
 }
+$dataArray['notEnoughRuns'] = $notEnoughRuns;
 
 $plotData = json_encode($dataArray);

--- a/libraries/graphs/boxplot/render.template.html
+++ b/libraries/graphs/boxplot/render.template.html
@@ -22,7 +22,7 @@
         if(config['data']['notEnoughRuns'] === true){
             document.getElementById('[[plotId]]').parentElement.style.setProperty('text-align', 'center');
             document.getElementById('[[plotId]]').parentElement.style.setProperty('font-weight', 'bold');
-            document.getElementById('[[plotId]]').parentElement.innerHTML = "BoxPlots need at least xxxx runs to have enough data!";
+            document.getElementById('[[plotId]]').parentElement.innerHTML = "BoxPlots need at least 3 runs to have enough data!";
         }
         else {
             new Chart(document.getElementById("[[plotId]]").getContext("2d"), config);

--- a/libraries/graphs/boxplot/render.template.html
+++ b/libraries/graphs/boxplot/render.template.html
@@ -20,8 +20,7 @@
             }
         };
         if(config['data']['notEnoughRuns'] === true){
-            document.getElementById('[[plotId]]').innerHTML = "BoxPlots need at least xxxx runs to have enough data!";
-            document.getElementById('[[plotId]]').style.removeProperty('height');
+            document.getElementById('[[plotId]]').parentElement.innerHTML = "BoxPlots need at least xxxx runs to have enough data!";
         }
         else {
             new Chart(document.getElementById("[[plotId]]").getContext("2d"), config);

--- a/libraries/graphs/boxplot/render.template.html
+++ b/libraries/graphs/boxplot/render.template.html
@@ -20,6 +20,8 @@
             }
         };
         if(config['data']['notEnoughRuns'] === true){
+            document.getElementById('[[plotId]]').parentElement.style.setProperty('text-align', 'center');
+            document.getElementById('[[plotId]]').parentElement.style.setProperty('font-weight', 'bold');
             document.getElementById('[[plotId]]').parentElement.innerHTML = "BoxPlots need at least xxxx runs to have enough data!";
         }
         else {

--- a/libraries/graphs/boxplot/render.template.html
+++ b/libraries/graphs/boxplot/render.template.html
@@ -19,8 +19,9 @@
                 tooltipDecimals: 3
             }
         };
-        if(data['notEnoughRuns'] === true){
+        if(config['data']['notEnoughRuns'] === true){
             document.getElementById('[[plotId]]').innerHTML = "BoxPlots need at least xxxx runs to have enough data!";
+            document.getElementById('[[plotId]]').style.removeProperty('height');
         }
         else {
             new Chart(document.getElementById("[[plotId]]").getContext("2d"), config);

--- a/libraries/graphs/boxplot/render.template.html
+++ b/libraries/graphs/boxplot/render.template.html
@@ -19,7 +19,12 @@
                 tooltipDecimals: 3
             }
         };
-        new Chart(document.getElementById("[[plotId]]").getContext("2d"), config);
+        if(data['notEnoughRuns'] === true){
+            document.getElementById('[[plotId]]').innerHTML = "BoxPlots need at least xxxx runs to have enough data!";
+        }
+        else {
+            new Chart(document.getElementById("[[plotId]]").getContext("2d"), config);
+        }
     }
 
 


### PR DESCRIPTION
When there are less than 3 runs on an evaluation, the rendering of the box plot would cause errors as there is not enough data. This gets catched now, and replaces the plot with an informational message that the plot cannot  be shown.