### PR TITLE
Result plots can be viewed when at least one job successfully finished

### DIFF
--- a/controllers/evaluation.php
+++ b/controllers/evaluation.php
@@ -144,15 +144,19 @@ class Evaluation_Controller extends Controller {
                 $this->view->assign('supportsShowResults', $sys->supportsFullResults());
                 // check if all jobs have finished
                 $isFinished = true;
+                $resultsAvailable = false;
                 foreach ($jobs as $subJob) {
                     if ($subJob->getStatus() != Define::JOB_STATUS_FINISHED) {
                         $isFinished = false;
+                    } else {
+                        $resultsAvailable = true;
                     }
                 }
                 if (sizeof($jobs) == 0) {
                     $isFinished = false;
                 }
                 $this->view->assign('isFinished', $isFinished);
+                $this->view->assign('resultsAvailable', $resultsAvailable);
             } else {
                 throw new Exception("No evaluation with id: " . $this->get['id']);
             }

--- a/controllers/results.php
+++ b/controllers/results.php
@@ -25,9 +25,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
  */
 
-use DBA\Evaluation;
-use DBA\Event;
-use DBA\Experiment;
 use DBA\Job;
 use DBA\QueryFilter;
 

--- a/controllers/results.php
+++ b/controllers/results.php
@@ -68,13 +68,14 @@ class Results_Controller extends Controller {
         $system = new System($evaluation->getSystemId());
         $experiment = $FACTORIES::getExperimentFactory()->get($evaluation->getExperimentId());
         $builder = new Results_Library($system);
-        $qF = new QueryFilter(Job::EVALUATION_ID, $evaluation->getId(), "=");
-        $jobs = $FACTORIES::getJobFactory()->filter(array($FACTORIES::FILTER => $qF));
+        $qF1 = new QueryFilter(Job::EVALUATION_ID, $evaluation->getId(), "=");
+        $qF2 = new QueryFilter(Job::STATUS, Define::JOB_STATUS_FINISHED, "=");
+        $jobs = $FACTORIES::getJobFactory()->filter([$FACTORIES::FILTER => [$qF1, $qF2]]);
 
         // group jobs with same settings together
         $groupedJobs = [];
-        foreach($jobs as $job){
-            if(!isset($groupedJobs[$job->getConfigurationIdentifier()])){
+        foreach ($jobs as $job) {
+            if (!isset($groupedJobs[$job->getConfigurationIdentifier()])) {
                 $groupedJobs[$job->getConfigurationIdentifier()] = [];
             }
             $groupedJobs[$job->getConfigurationIdentifier()][] = $job;

--- a/views/evaluation/detail.php
+++ b/views/evaluation/detail.php
@@ -135,7 +135,7 @@ $this->includeInlineCSS("
 
                     <div class="clearfix">
                       <!-- Show Results -->
-                      <?php if ($data['isFinished'] === true && $data['supportsShowResults'] === true) { ?>
+                      <?php if ($data['resultsAvailable'] === true && $data['supportsShowResults'] === true) { ?>
                           <a class="btn btn-app" href="/results/show/id=<?php echo $data['evaluation']->getId(); ?>">
                               <i class="fa fa-chart-bar "></i> Results
                           </a>


### PR DESCRIPTION
Depending on the plotting configuration, not all plots are useful with only one job, but certain results can then already be viewed.

closes issue #39 