### PR TITLE
Trigger change event after changing value of field

### DIFF
--- a/views/builder/create.php
+++ b/views/builder/create.php
@@ -37,6 +37,7 @@ $this->includeInlineJS("
             r = Math.floor(r);
         }
         result.val(r);
+        result.trigger('change');
     }
     
     function checkPercentages(dependency){


### PR DESCRIPTION
the onchange event is not fired when changing the value with .val(), so an extra event is fired when changing the values automatically.

closes #93 