### PR TITLE
Hide plots of single results if not defined

### DIFF
--- a/libraries/results.php
+++ b/libraries/results.php
@@ -274,7 +274,9 @@ class Results_Library {
                 }
                 $view->includeInlineJS("plot" . $p['plotId'] . "();");
             }
-            $content .= $wrapperTemplate->render(['plotData' => $wrapperContent, 'title' => $title]);
+            if (sizeof($this->json[Results_Library::TYPE_JOB]) > 0) {
+                $content .= $wrapperTemplate->render(['plotData' => $wrapperContent, 'title' => $title]);
+            }
         }
         $dataTemplate = new Template("builder/data");
         $dataObjects['plots'] = json_encode($dataObjects['plots']);


### PR DESCRIPTION
If there are not plots defined for single results, the page is filled with empty cards for each job configuration combination. This fix only shows these, if there is at least one single job result plot defined.