### PR TITLE
Fix permission check for archiving experiments and evaluations

### DIFF
--- a/controllers/experiment.php
+++ b/controllers/experiment.php
@@ -95,7 +95,7 @@ class Experiment_Controller extends Controller {
                         $experiment->setResultId($this->get['select']);
                         Factory::getExperimentFactory()->update($experiment);
                     }
-                } else if (!empty($this->post['archiveEvaluation']) && ($project->getUserId() == $auth->getUserID() || $auth->isAdmin())) {
+                } else if (!empty($this->post['archiveEvaluation'])) {
                     $evaluation = Factory::getEvaluationFactory()->get($this->post['evaluationId']);
                     if ($evaluation == null) {
                         throw new ProcessException("Invalid Evaluation!");
@@ -112,7 +112,7 @@ class Experiment_Controller extends Controller {
                     }
                     $evaluation->setIsArchived(1);
                     Factory::getEvaluationFactory()->update($evaluation);
-                } else if (!empty($this->post['unarchiveEvaluation']) && ($project->getUserId() == $auth->getUserID() || $auth->isAdmin())) {
+                } else if (!empty($this->post['unarchiveEvaluation'])) {
                     $evaluation = Factory::getEvaluationFactory()->get($this->post['evaluationId']);
                     if ($evaluation == null) {
                         throw new ProcessException("Invalid Evaluation!");

--- a/controllers/project.php
+++ b/controllers/project.php
@@ -191,7 +191,7 @@ class Project_Controller extends Controller {
             else if (!empty($this->get['unarchive']) && $this->get['unarchive'] == true && ($project->getUserId() == $auth->getUserID() || $auth->isAdmin())) {
                 $project->setIsArchived(0);
                 Factory::getProjectFactory()->update($project);
-            } else if (!empty($this->post['archiveExperiment']) && ($project->getUserId() == $auth->getUserID() || $auth->isAdmin())) {
+            } else if (!empty($this->post['archiveExperiment'])) {
                 $experiment = Factory::getExperimentFactory()->get($this->post['experimentId']);
                 if ($experiment == null) {
                     throw new ProcessException("Invalid Experiment!");
@@ -209,7 +209,7 @@ class Project_Controller extends Controller {
                 }
                 $experiment->setIsArchived(1);
                 Factory::getExperimentFactory()->update($experiment);
-            } else if (!empty($this->post['unarchiveExperiment']) && ($project->getUserId() == $auth->getUserID() || $auth->isAdmin())) {
+            } else if (!empty($this->post['unarchiveExperiment'])) {
                 $experiment = Factory::getExperimentFactory()->get($this->post['experimentId']);
                 if ($experiment == null) {
                     throw new ProcessException("Invalid Experiment!");


### PR DESCRIPTION
As for the project and experiment view there is checked anyway if a person is allowed to see the page, there is no additional check needed for the archive/unarchive action itself, as everyone who is able to see the experiment/evaluation (project owner, admin, projects users) is allowed to execute this action.

closes #146