### PR TITLE
Require manual deployment decision for experiments

### DIFF
--- a/libraries/builder.php
+++ b/libraries/builder.php
@@ -110,9 +110,9 @@ class Builder_Library {
             } else {
                 # Added this if statement because, creating the first experiment (on devl stage)
                 # throws:  htmlentities(): Passing null to parameter #1 ($string) of type string is deprecated in /usr/local/web/chronos/libraries/builder.php on line 111
-                if($val == null) {
-                    $val = "";
-                }
+                #if($val == null) {
+                #    $val = "";
+                #}
                 $escaped[$key] = htmlentities($val, ENT_QUOTES, "UTF-8");
             }
         }

--- a/libraries/builder.php
+++ b/libraries/builder.php
@@ -108,11 +108,9 @@ class Builder_Library {
             if (is_array($val)) {
                 $escaped[$key] = $this->escapeArrayValues($val);
             } else {
-                # Added this if statement because, creating the first experiment (on devl stage)
-                # throws:  htmlentities(): Passing null to parameter #1 ($string) of type string is deprecated in /usr/local/web/chronos/libraries/builder.php on line 111
-                #if($val == null) {
-                #    $val = "";
-                #}
+                if($val == null) {
+                    $val = "";
+                }
                 $escaped[$key] = htmlentities($val, ENT_QUOTES, "UTF-8");
             }
         }

--- a/libraries/builder.php
+++ b/libraries/builder.php
@@ -108,6 +108,11 @@ class Builder_Library {
             if (is_array($val)) {
                 $escaped[$key] = $this->escapeArrayValues($val);
             } else {
+                # Added because creating an experiment
+                # throws:  htmlentities(): Passing null to parameter #1 ($string) of type string is deprecated in /usr/local/web/chronos/libraries/builder.php on line 111
+                if($val == null) {
+                    $val = "";
+                }
                 $escaped[$key] = htmlentities($val, ENT_QUOTES, "UTF-8");
             }
         }

--- a/libraries/builder.php
+++ b/libraries/builder.php
@@ -108,7 +108,7 @@ class Builder_Library {
             if (is_array($val)) {
                 $escaped[$key] = $this->escapeArrayValues($val);
             } else {
-                # Added because creating an experiment
+                # Added this if statement because, creating the first experiment (on devl stage)
                 # throws:  htmlentities(): Passing null to parameter #1 ($string) of type string is deprecated in /usr/local/web/chronos/libraries/builder.php on line 111
                 if($val == null) {
                     $val = "";

--- a/views/builder/create.php
+++ b/views/builder/create.php
@@ -197,6 +197,7 @@ $this->includeInlineCSS("
                                 <div class="form-group">
                                     <label>Select deployment</label>
                                     <select id="environment" name="deployment" class="form-control">
+                                        <option value="" disabled selected>Please select an item</option>
                                         <?php if(!empty($data['deployments'])) { ?>
                                             <?php foreach ($data['deployments'] as $deployment) { ?>
                                                 <option value="<?php echo $deployment->getItem(); ?>" <?php if($data['copyData']['deployment'] == $deployment->getItem()) echo 'selected'; ?>><?php echo $deployment->getItem(); ?></option>

--- a/views/builder/create.php
+++ b/views/builder/create.php
@@ -196,7 +196,7 @@ $this->includeInlineCSS("
                                 </div>
                                 <div class="form-group">
                                     <label>Select deployment</label>
-                                    <select id="environment" name="deployment" class="form-control">
+                                    <select id="environment" name="deployment" class="form-control" required>
                                         <option value="" disabled selected>Please select an item</option>
                                         <?php if(!empty($data['deployments'])) { ?>
                                             <?php foreach ($data['deployments'] as $deployment) { ?>

--- a/views/builder/create.php
+++ b/views/builder/create.php
@@ -197,7 +197,7 @@ $this->includeInlineCSS("
                                 <div class="form-group">
                                     <label>Select deployment</label>
                                     <select id="environment" name="deployment" class="form-control" required>
-                                        <option value="" disabled selected>Please select an item</option>
+                                        <option value="" disabled selected>Please select a deployment</option>
                                         <?php if(!empty($data['deployments'])) { ?>
                                             <?php foreach ($data['deployments'] as $deployment) { ?>
                                                 <option value="<?php echo $deployment->getItem(); ?>" <?php if($data['copyData']['deployment'] == $deployment->getItem()) echo 'selected'; ?>><?php echo $deployment->getItem(); ?></option>

--- a/views/experiment/detail.php
+++ b/views/experiment/detail.php
@@ -125,7 +125,7 @@ $this->includeInlineJS("
                                 </div>
                                 <div class="form-group">
                                     <label>Select deployment</label>
-                                    <select id="deployment" name="deployment" class="form-control">
+                                    <select id="deployment" name="deployment" class="form-control" required>
                                         <?php if(!empty($data['deployments'])) { ?>
                                             <?php foreach ($data['deployments'] as $deployment) { ?>
                                                 <option value="<?php echo $deployment->getItem(); ?>" <?php if(isset(json_decode($data['experiment']->getPostData(), true)['deployment']) && json_decode($data['experiment']->getPostData(), true)['deployment'] == $deployment->getItem()) echo 'selected'; ?>><?php echo $deployment->getItem(); ?></option>

--- a/views/project/create.php
+++ b/views/project/create.php
@@ -71,14 +71,6 @@ SOFTWARE.
                             <?php } ?>
                         </select>
                     </div>
-                    <div class="form-group">
-                        <label>Add System</label>
-                        <select id="add_system" name="add_system" class="form-control required">
-                            <?php foreach ($data['systems'] as $s) { /** @var $s \DBA\System */ ?>
-                                <option value="<?php echo $s->getId(); ?>"><?php echo $s->getName(); ?></option>
-                            <?php } ?>
-                        </select>
-                    </div>
                 </div>
                 <div class="box-footer">
                     <button type="submit" class="btn btn-primary pull-right">Create</button>

--- a/views/project/create.php
+++ b/views/project/create.php
@@ -71,6 +71,14 @@ SOFTWARE.
                             <?php } ?>
                         </select>
                     </div>
+                    <div class="form-group">
+                        <label>Add System</label>
+                        <select id="add_system" name="add_system" class="form-control required">
+                            <?php foreach ($data['systems'] as $s) { /** @var $s \DBA\System */ ?>
+                                <option value="<?php echo $s->getId(); ?>"><?php echo $s->getName(); ?></option>
+                            <?php } ?>
+                        </select>
+                    </div>
                 </div>
                 <div class="box-footer">
                     <button type="submit" class="btn btn-primary pull-right">Create</button>


### PR DESCRIPTION
Creating a new experiment did fill the deployment field automatically, making it easy for the user to overlook.