### PR TITLE
Fix line plots in result representation

### DIFF
--- a/core/util.php
+++ b/core/util.php
@@ -466,4 +466,17 @@ class Util {
         return $newId;
     }
 
+    public static function updateSumsAndCounts($array, &$sums, &$counts) {
+        foreach ($array as $index => $value) {
+            if (isset($sums[$index])) {
+                $sums[$index] += $value;
+                $counts[$index] += 1;
+            } else {
+                $sums[$index] = $value;
+                $counts[$index] = 1;
+            }
+        }
+    }
+}
+
 }


### PR DESCRIPTION
This PR re-adds the incorrectly removed `updateSumsAndCounts` function to the utils file to fix the result representation of line-plots.